### PR TITLE
docs: add getSchulaufgabenplan to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ const bulletinFile = await client.getSchwarzesBrettFile(fileId);
 const letterFile = await client.getElternbrief(letterId);
 ```
 
+#### Get exam schedule
+
+```typescript
+const examSchedule = await client.getSchulaufgabenplan();
+```
+
 ## Types 📝
 
 The library includes TypeScript definitions for various data structures:


### PR DESCRIPTION
This commit adds documentation for the 'getSchulaufgabenplan()` method which was implemented in the codebase but missing from the README documentation.