### PR TITLE
Fix conversion of substitutionDate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -389,7 +389,7 @@ class ElternPortalApiClient {
       if (!match || match.length != 4) {
         return false;
       }
-      const substitutionDate = new Date(+match[3], +match[2], +match[1]);
+      const substitutionDate = new Date(+match[3], +match[2] - 1, +match[1]);
 
       // find matching table
       const table = $element.next();


### PR DESCRIPTION
JS months start with zero. (As correctly considered in the conversions above)